### PR TITLE
WIP: Patch up gemfile errors

### DIFF
--- a/type-on-strap.gemspec
+++ b/type-on-strap.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "type-on-strap"
-  spec.version       = "2.3.8"
+  spec.version       = "2.4.4"
   spec.authors       = ["Sylhare", "Rohan Chandra"]
   spec.email         = ["sylhare@outlook.com", "hellorohan@outlook.com"]
 


### PR DESCRIPTION
You added `gemspec` at the end of the gemfile, which is just redundant. Adding the packages there is useless too, just watch the build logs once this is out of draft.